### PR TITLE
Doesn't compile with Arduino 1.0.6

### DIFF
--- a/ESP8266.cpp
+++ b/ESP8266.cpp
@@ -636,15 +636,15 @@ int ESP8266::read()
     return -1;
 }
 
-int ESP8266::read(char* buf, size_t size)
+int ESP8266::read(char *buffer, size_t length)
 {
     int readable;
 
     if (available() > 0) {
-        readable = min(size, _available);
+        readable = min(length, _available);
         _available -= readable;
         _serial->setTimeout(_timeout);
-        return _serial->readBytes(buf, readable);
+        return _serial->readBytes(buffer, readable);
     }
 
     return -1;

--- a/ESP8266.h
+++ b/ESP8266.h
@@ -191,7 +191,7 @@ public:
 
     // Read
     int read();
-    int read(char* buf, size_t size);
+    int read(char *buffer, size_t length);
 
 protected:
     Stream* _serial;


### PR DESCRIPTION
ESP8266.cpp:647: error: invalid conversion from 'uint8_t_' to 'char_'

Changed buffer type and added missing right curly bracket.
