### PR TITLE
ESP8266Server class

### DIFF
--- a/ESP8266Server.cpp
+++ b/ESP8266Server.cpp
@@ -1,0 +1,19 @@
+#include "ESP8266Server.h"
+
+void ESP8266Server::begin()
+{
+    for (unsigned int i = 0; i < 5; i++){
+        _clients[i] = new ESP8266Client(_esp8266, i);
+    }
+    
+    _esp8266.createServer(_port);
+}
+
+ESP8266Client * ESP8266Server::available()
+{
+    if(_esp8266.available()>0){
+        return _clients[_esp8266.getId()];
+    } else {
+        return NULL;
+    }
+}

--- a/ESP8266Server.cpp
+++ b/ESP8266Server.cpp
@@ -5,13 +5,13 @@ void ESP8266Server::begin()
     for (unsigned int i = 0; i < 5; i++){
         _clients[i] = new ESP8266Client(_esp8266, i);
     }
-    
+
     _esp8266.createServer(_port);
 }
 
 ESP8266Client * ESP8266Server::available()
 {
-    if(_esp8266.available()>0){
+    if(_esp8266.available() > 0){
         return _clients[_esp8266.getId()];
     } else {
         return NULL;

--- a/ESP8266Server.cpp
+++ b/ESP8266Server.cpp
@@ -2,7 +2,7 @@
 
 void ESP8266Server::begin()
 {
-    for (unsigned int i = 0; i < 5; i++){
+    for (unsigned int i = 0; i < ESP8266_MAX_CONNECTIONS; i++){
         _clients[i] = new ESP8266Client(_esp8266, i);
     }
 

--- a/ESP8266Server.h
+++ b/ESP8266Server.h
@@ -7,7 +7,7 @@
 class ESP8266Server
 {
 public:
-    ESP8266Server(ESP8266& esp8266, uint16_t port)  :  _esp8266(esp8266),  _port(port)  {} ;
+    ESP8266Server(ESP8266& esp8266, uint16_t port) : _esp8266(esp8266), _port(port) {}
     ESP8266Client * available();
     virtual void begin();
 

--- a/ESP8266Server.h
+++ b/ESP8266Server.h
@@ -13,7 +13,7 @@ public:
 
 protected:
     uint16_t _port;
-    ESP8266Client * _clients[5];
+    ESP8266Client * _clients[ESP8266_MAX_CONNECTIONS];
     ESP8266 _esp8266;
 };
 

--- a/ESP8266Server.h
+++ b/ESP8266Server.h
@@ -1,0 +1,20 @@
+#ifndef ESP8266Server_h
+#define ESP8266Server_h
+
+#include "ESP8266.h"
+#include "ESP8266Client.h"
+
+class ESP8266Server
+{
+public:
+    ESP8266Server(ESP8266& esp8266, uint16_t port)  :  _esp8266(esp8266),  _port(port)  {} ;
+    ESP8266Client * available();
+    virtual void begin();
+
+protected:
+    uint16_t _port;
+    ESP8266Client * _clients[5];
+    ESP8266 _esp8266;
+};
+
+#endif

--- a/examples/Server/Server.ino
+++ b/examples/Server/Server.ino
@@ -1,0 +1,53 @@
+#include <ESP8266.h>
+#include <ESP8266Server.h>
+
+ESP8266 wifi = ESP8266(Serial1);
+ESP8266Server server(wifi, 80);
+IPAddress ip;
+
+void setup() {
+  Serial.begin(115200);
+  Serial1.begin(115200);
+
+  wifi.begin();
+  wifi.setMode(ESP8266_WIFI_BOTH);
+  wifi.setMultipleConnections(true);
+  wifi.joinAP("ssid", "p4ssw0rd");
+
+  wifi.getIP(ESP8266_WIFI_STATION, ip);
+  Serial.println(ip);
+
+  server.begin();
+}
+
+void loop(){
+
+  ESP8266Client * client = server.available();
+
+  if (client){
+    while(client->available()){
+      Serial.write(client->read());
+    }
+
+    client->print(
+      "HTTP/1.0 200 OK\r\n"
+      "Content-Type: text/html\r\n\r\n"
+      "<html>\r\n"
+      "<head>\r\n"
+      "<title>ESP8266Server</title>\r\n"
+      "</head>\r\n"
+      "<body>\r\n"
+      "<h1>IP: "
+      );
+      
+    client->print(ip);
+    
+    client->print(
+      "<h1>\r\n"
+      "</body>\r\n"
+      "</html>"
+      );
+
+    client->stop();
+  }
+}

--- a/keywords.txt
+++ b/keywords.txt
@@ -3,6 +3,7 @@ ESP8266                            	KEYWORD1
 ESP8266Connection                  	KEYWORD1
 ESP8266Station                     	KEYWORD1
 ESP8266Client                      	KEYWORD1
+ESP8266Server                      	KEYWORD1
 
 # Method
 begin                              	KEYWORD2


### PR DESCRIPTION
Currently the usage of ESP8622Client is hard  when runnig as server because the ESP8622Client writes to the default channel if the channel id is not specified in the constructor. 

The new ESP8622Server class returns a ESP8622Client instance with the correct channel id set when data is available.

You probably had something similar already in mind. Please let me know if you want me to change something.
