### PR TITLE
Avoid mix block with different ID

### DIFF
--- a/ESP8266.cpp
+++ b/ESP8266.cpp
@@ -558,8 +558,8 @@ unsigned int ESP8266::getId()
 int ESP8266::read()
 {
     if (_available) {
-        int c =    _serial->read();
-        if (c >= 0 && _available > 0) {
+        int c = _serial->read();
+        if (c >= 0) {
             _available--;
         }
         return c;

--- a/ESP8266.cpp
+++ b/ESP8266.cpp
@@ -510,6 +510,10 @@ int ESP8266::available()
 {
     int tmp;
     int c;
+	
+    // check if already receiving
+    if (_available > 0)
+	    return _available;
 
     // incoming sequence is +IPD,id,length:data or +IPD,length:data
     // non-blocking search of '+'

--- a/ESP8266.h
+++ b/ESP8266.h
@@ -102,7 +102,7 @@ public:
     ESP8266CommandStatus getMode(ESP8266WifiMode* mode);
 
     // Join the access point
-    ESP8266CommandStatus joinAP(char* ssid, char* password);
+    ESP8266CommandStatus joinAP(const char* ssid, const char* password);
 
     // Get the current access point
     ESP8266CommandStatus getAP(char* ssid);


### PR DESCRIPTION
I tried to solve problem with mixing +IPD blocks with different id to one stream.
The most easiest solution is limit all read() method to only one +IPD block, then user will call available() again and get another block, it can be with the same or another ID. What is you onion on this?

I also removed infinite loop in read() a peek() method because it is unsafe and against Stream class documentation. For example if user of library will do some blocking operation during data arrive, it can skip some data on RX pin and the your implementation end in infinite loop, because available() was still return non zero value, but no additional data will arrive, there is no way to leave this deadlock.

I also fixes several compilation warning, like compare signed and unsigned variables, deprecated string conversion, etc.

I found interesting think. It is not possible to use readString(), because it it too slow and cause skip some data on the SoftwareSerialPort with 9600bps
